### PR TITLE
v3.3.10: Switched the default stable coin to USDT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.3.10
+
+* Switched the default stable coin to USDT. BUSD will be removed by the end of 2023.
+
 # v3.3.9
 
 * Added "Replenish fees budget" setting.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "trading-helper",
-    "version": "3.3.9",
+    "version": "3.3.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "trading-helper",
-            "version": "3.3.9",
+            "version": "3.3.10",
             "license": "MIT",
             "dependencies": {
                 "@emotion/react": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "trading-helper",
-    "version": "3.3.9",
+    "version": "3.3.10",
     "description": "",
     "scripts": {
         "glogin": "clasp login",

--- a/src/gas/dao/Config.ts
+++ b/src/gas/dao/Config.ts
@@ -17,7 +17,7 @@ export interface APIKeys {
 }
 
 export const DefaultConfig: () => Config = () => ({
-  StableCoin: StableUSDCoin.BUSD,
+  StableCoin: StableUSDCoin.USDT,
   StableBalance: AUTO_DETECT,
   FeesBudget: AUTO_DETECT,
   AutoReplenishFees: false,

--- a/src/lib/Types.ts
+++ b/src/lib/Types.ts
@@ -1,8 +1,8 @@
 import Integer = GoogleAppsScript.Integer;
 
 export enum StableUSDCoin {
-  BUSD = `BUSD`,
   USDT = `USDT`,
+  BUSD = `BUSD`, // TODO: remove once it dies out
 }
 
 export enum OtherStableCoins {


### PR DESCRIPTION
# v3.3.10

* Switched the default stable coin to USDT. BUSD will be removed by the end of 2023.